### PR TITLE
Add Renovate configuration

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,53 @@
+{
+	"extends": [
+		"config:base"
+	],
+	"baseBranches": [
+		"development"
+	],
+	"packageRules": [
+		{
+			"matchDepTypes": [
+				"peerDependencies"
+			],
+			"groupName": "peer and related dependencies",
+			"groupSlug": "peer-related-deps",
+			"updateTypes": [
+				"patch",
+				"minor"
+			],
+			"additionalBranchPrefix": "peer-deps/",
+			"matchPackagePatterns": [
+				"@effect/*",
+				"effect",
+				"kysely"
+			],
+			"schedule": [
+				"before 5am on Monday"
+			]
+		},
+		{
+			"matchPackagePatterns": [
+				"@effect/*",
+				"effect",
+				"kysely"
+			],
+			"groupName": "effect and kysely dependencies",
+			"groupSlug": "effect-kysely-deps",
+			"updateTypes": [
+				"patch",
+				"minor"
+			],
+			"schedule": [
+				"before 5am on Monday"
+			]
+		}
+	],
+	"branchPrefix": "renovate/",
+	"prHourlyLimit": 5,
+	"prConcurrentLimit": 10,
+	"dependencyDashboard": true,
+	"labels": [
+		"dependencies"
+	]
+}


### PR DESCRIPTION
To prevent dependency warnings like `YN0060: │ @effect/sql is listed by your project with version 0.6.2 (p241ef), which doesn't satisfy what effect-sql-kysely requests (~0.3.9).`, this pull request adds a Renovate configuration to the repository to manage dependency updates. The configuration includes:

- Grouping peer dependencies and related packages (@effect/*, effect, kysely) and allowing patch and minor updates.
- Specific scheduling for checking and updating dependencies.
- Branch prefix and concurrency limits to manage the flow of updates.

Install Renovate GitHub App:
   - Go to the [Renovate GitHub App page](https://github.com/apps/renovate).
   - Click the "Install" button.
   - Choose the account and repository where you want to install Renovate.
   - Select the repository `TylorS/effect-sql-kysely` and click "Install".
