### PR TITLE
Kysely doesn't reexport node-pg's `Pool`

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -212,12 +212,13 @@ Effect.runPromise(main);
 ```typescript
 import * as Database from "effect-sql-kysely/Pg";
 import * as kysely from "kysely";
+import { Pool } from "pg";
 
 const databaseLayer = MyDatabase.layer({
   acquire: Effect.sync(() =>
     new kysely.Kysely<DatabaseSchema>({
       dialect: new kysely.PostgresDialect({
-        pool: new kysely.Pool({
+        pool: new Pool({
           host: "localhost",
           port: 5432,
           user: "postgres",


### PR DESCRIPTION
It does have a `PostgresPool` that's an interface used by `PostgresDialectConfig`, but it doesn't reexport the actual function/class underneath. Since the official kysely documentation imports `Pool` from `pg`, follow that example instead.